### PR TITLE
Fix deprecations for v10 in v2.x

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -2,15 +2,16 @@
 defined('TYPO3_MODE') or die();
 
 call_user_func(function () {
+    $passwordControllerClass = version_compare(TYPO3_version, '10.0', '>=') ? \Derhansen\FeChangePwd\Controller\PasswordController::class : 'Password';
     \TYPO3\CMS\Extbase\Utility\ExtensionUtility::configurePlugin(
         'Derhansen.fe_change_pwd',
         'Pi1',
         [
-            'Password' => 'edit,update',
+            $passwordControllerClass => 'edit,update',
         ],
         // non-cacheable actions
         [
-            'Password' => 'edit,update',
+            $passwordControllerClass => 'edit,update',
         ]
     );
 });

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -4,7 +4,7 @@ defined('TYPO3_MODE') or die();
 call_user_func(function () {
     $passwordControllerClass = version_compare(TYPO3_version, '10.0', '>=') ? \Derhansen\FeChangePwd\Controller\PasswordController::class : 'Password';
     \TYPO3\CMS\Extbase\Utility\ExtensionUtility::configurePlugin(
-        'Derhansen.fe_change_pwd',
+        version_compare(TYPO3_version, '10.0', '>=') ? 'fe_change_pwd' : 'Derhansen.fe_change_pwd',
         'Pi1',
         [
             $passwordControllerClass => 'edit,update',


### PR DESCRIPTION
.. so that people using fe_change_pwd v2 on TYPO3v10 don't get deprecation notices. We still keep support for TYPO3 v9.